### PR TITLE
fix: binja plugin incorrectly applying IOKit symbolication data

### DIFF
--- a/plugins/binja/__init__.py
+++ b/plugins/binja/__init__.py
@@ -22,9 +22,9 @@
 
 import json
 from binaryninja import *
-from binaryninja import Architecture, BinaryView, Logger, PluginCommand
+from binaryninja import Architecture, BinaryView, Logger, PluginCommand, SectionSemantics, Symbol, SymbolType
 from binaryninja.demangle import demangle_generic
-from binaryninja.types import FunctionType
+from binaryninja.types import FunctionParameter, FunctionType, Type
 
 
 def run(bv: BinaryView) -> None:
@@ -43,8 +43,17 @@ def run(bv: BinaryView) -> None:
     apply_symbols_and_create_functions(bv=bv, log=log, symbols=symbols)
 
 
+def is_executable_address(bv: BinaryView, address: int) -> bool:
+    sections = bv.get_sections_at(address)
+    for section in sections:
+        if section.semantics == SectionSemantics.ReadOnlyCodeSectionSemantics:
+            return True
+    return False
+
+
 def apply_symbols_and_create_functions(bv: BinaryView, log: Logger, symbols: dict[str, str]) -> None:
-    count = 0
+    func_count = 0
+    data_count = 0
     arch = bv.arch
     assert arch is not None, "Architecture should be available for a kernelcache"
     for address_str, symbol_name in symbols.items():
@@ -55,44 +64,56 @@ def apply_symbols_and_create_functions(bv: BinaryView, log: Logger, symbols: dic
             if address < bv.start or address >= bv.end:
                 log.log_info(f"Address {hex(address)} is out of range for this binary")
                 continue
-            # Create a function if it doesn't exist
-            if not bv.get_function_at(address):
-                bv.create_user_function(address)
-                log.log_info(f"Created function at address {hex(address)}")
-            # Get the function
-            func = bv.get_function_at(address)
-            if func:
-                demangled_name = demangle_symbol_if_mangled(symbol_name, arch)
-                # Set the function name (which also creates the symbol)
-                func.name = demangled_name
-                if demangled_name != symbol_name:
-                    log.log_debug(f"[Symbolicated] 0x{hex(address)}: {symbol_name} -> {demangled_name}")
+
+            if is_executable_address(bv, address):
+                # Create a function if it doesn't exist
+                if not bv.get_function_at(address):
+                    bv.create_user_function(address)
+                    log.log_info(f"Created function at address {hex(address)}")
+                # Get the function
+                func = bv.get_function_at(address)
+                if func:
+                    demangled_name, func_type = demangle_symbol_if_mangled(symbol_name, arch)
+                    # Set the function name (which also creates the symbol)
+                    func.name = demangled_name
+                    # Apply the type signature if available
+                    if func_type is not None:
+                        func.type = func_type
+                    if demangled_name != symbol_name:
+                        log.log_debug(f"[Symbolicated] {hex(address)}: {symbol_name} -> {demangled_name}")
+                    else:
+                        log.log_debug(f"[Symbolicated] {hex(address)}: {symbol_name}")
                 else:
-                    log.log_debug(f"[Symbolicated] 0x{hex(address)}: {symbol_name}")
+                    log.log_error(f"Failed to create or get function at address {hex(address)}")
+                func_count += 1
             else:
-                log.log_error(f"Failed to create or get function at address {hex(address)}")
-            count += 1
+                # Create a data symbol instead of a function
+                bv.define_user_symbol(Symbol(SymbolType.DataSymbol, address, symbol_name))
+                log.log_debug(f"[Data] {hex(address)}: {symbol_name}")
+                data_count += 1
         except ValueError:
             log.log_error(f"Error parsing address: {address_str}")
         except Exception as e:
             log.log_error(f"Error processing symbol: {symbol_name} at {address_str} - {str(e)}")
-    log.log_info(f"🎉 Symbolicated {count} addresses 🎉")
+    log.log_info(f"🎉 Symbolicated {func_count} functions and {data_count} data symbols 🎉")
 
 
-def demangle_symbol_if_mangled(symbol_name: str, arch: Architecture) -> str:
+def demangle_symbol_if_mangled(symbol_name: str, arch: Architecture) -> tuple[str, FunctionType | None]:
     if symbol_name.startswith("__Z"):
         demangle_result = demangle_generic(arch, symbol_name)
         if demangle_result is not None:
             type_signature, name_tokens = demangle_result
-
             demangled_name = "::".join(name_tokens)
-
             if isinstance(type_signature, FunctionType):
-                params_str = ", ".join([str(p.type) for p in type_signature.parameters])
-                return f"{demangled_name}({params_str})"
-
-            return demangled_name
-    return symbol_name
+                # Check if this is a member function (has class::method pattern)
+                # and add implicit 'this' pointer as first parameter
+                if len(name_tokens) >= 2:
+                    this_param = FunctionParameter(Type.pointer(arch, Type.void()), "this")
+                    new_params = [this_param] + list(type_signature.parameters)
+                    type_signature = Type.function(type_signature.return_value, new_params)
+                return demangled_name, type_signature
+            return demangled_name, None
+    return symbol_name, None
 
 
 def is_valid(bv: BinaryView) -> bool:


### PR DESCRIPTION
# Summary 

`ipsw kernel symbolicate` now recovers information about IOKit methods and classes. While this information is very helpful -  this doesn't integrate well with in Binja. 

This causes two primary issues:

## Issue 1
Part of the information recovered by the additions to the ipsw kernel symbolicate are the vtable addresses:
```
ipsw kernel symbolicate kernelcache.release.iPhone16,2 | grep "vtable for OSDic"
   • Symbolicating...          kernelcache=kernelcache.release.iPhone16,2
   • Found                     bsd_syscall_table=0xfffffff007bfa0d0
   • Found                     mach_trap_table=0xfffffff007bcc000
   • Found                     mig_kern_subsystem table=0xfffffff00ade4a38
   • Discovered C++ kernel symbols added=12446 classes=3119
0xfffffff007bfe578 vtable for OSDictionary::MetaClass
0xfffffff007bfe408 vtable for OSDictionar
```

The todo references `add support for global variables/constants` - the recovered C++ vtables are effectively a series of global constants. As a result when applied using the Binary Ninja plugin you get non-sensical results such as:
```
fffffff007bfe408    int64_t vtable for OSDictionary()
fffffff007bfe408  24e2970a   ??
```

A better long term solution is likely to have the type data from the dwarf symbols feed down into the JSON that is consumed - but the fix of checking if the section is executable seems valid for now. 

## Issue 2 
IOKit C++ mangled names are incorrectly applied

The symbolication script now includes mangled C++ names.
```
jq . kernelcache.release.iPhone18,2.symbols.json | grep addDriver
  "18446741874831241752": "__ZN11IOCatalogue10addDriversEP7OSArrayb",
 ```
The way these are currently applied defines them as the function name rather than the function signature. This results in names such as:
```
int64_t* IOCatalogue::addDrivers(OSArray*, bool)(void* arg1, int64_t* arg2, int32_t arg3)
```

This PR corrects this so that the arguments are typed and named correctly.


# Testing
My changes were tested with the following kernel
```
ipsw download ipsw -d iPhone16,2 -b 23E254 --kernel
```

Binja 5.3.9393-dev




