### PR TITLE
Format generator imports

### DIFF
--- a/scripts/generate/generate.py
+++ b/scripts/generate/generate.py
@@ -35,7 +35,6 @@ import idautils
 import idc
 from idadex import ea_t
 from macho import get_section_by_name
-
 from symbolicator import Anchor, Signature, Symbolicator, Version
 
 

--- a/scripts/generate/generate_ida8.py
+++ b/scripts/generate/generate_ida8.py
@@ -36,7 +36,6 @@ import idautils
 import idc
 from idadex import ea_t
 from macho import get_section_by_name
-
 from symbolicator import Anchor, Signature, Symbolicator, Version
 
 


### PR DESCRIPTION
## Summary
- Format generator import grouping in `scripts/generate/generate.py` and `scripts/generate/generate_ida8.py`
- Align import layout with `isort` checks

## Validation
- `python -m black -l 120 --check C:\tmp\symbolicator\scripts`
- `python -m isort --check-only C:\tmp\symbolicator\scripts`

Conversation: https://app.warp.dev/conversation/4dacf81d-34ac-466d-bb4f-1fa38cc39da4

Co-Authored-By: Oz <oz-agent@warp.dev>